### PR TITLE
use activerecord 5.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 source "https://rubygems.org"
 
+gem "activerecord", '~> 5.2'
 gem "sinatra-activerecord"
 gem "sqlite3", '~> 1.3.6'
 gem "pry"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,58 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activemodel (5.2.4.1)
+      activesupport (= 5.2.4.1)
+    activerecord (5.2.4.1)
+      activemodel (= 5.2.4.1)
+      activesupport (= 5.2.4.1)
+      arel (>= 9.0)
+    activesupport (5.2.4.1)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 0.7, < 2)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
+    arel (9.0.0)
+    coderay (1.1.2)
+    concurrent-ruby (1.1.5)
+    faker (2.9.0)
+      i18n (>= 1.6, < 1.8)
+    i18n (1.7.0)
+      concurrent-ruby (~> 1.0)
+    method_source (0.9.2)
+    minitest (5.13.0)
+    mustermann (1.0.3)
+    pry (0.12.2)
+      coderay (~> 1.1.0)
+      method_source (~> 0.9.0)
+    rack (2.0.8)
+    rack-protection (2.0.7)
+      rack
+    require_all (3.0.0)
+    sinatra (2.0.7)
+      mustermann (~> 1.0)
+      rack (~> 2.0)
+      rack-protection (= 2.0.7)
+      tilt (~> 2.0)
+    sinatra-activerecord (2.0.14)
+      activerecord (>= 3.2)
+      sinatra (>= 1.0)
+    sqlite3 (1.3.13)
+    thread_safe (0.3.6)
+    tilt (2.0.10)
+    tzinfo (1.2.5)
+      thread_safe (~> 0.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  activerecord (~> 5.2)
+  faker
+  pry
+  require_all
+  sinatra-activerecord
+  sqlite3 (~> 1.3.6)
+
+BUNDLED WITH
+   2.0.2


### PR DESCRIPTION
The Gemfile doesn't specify an ActiveRecord version, so for students who are using Rails 6, this project is defaulting to ActiveRecord version 6. This causes issues with migrations and also with the SQLite gem version specified in this project's Gemfile.

I added an entry in the Gemfile to use ActiveRecord 5.2 to fix this issue.